### PR TITLE
Implement schema Exec middlewares

### DIFF
--- a/example/array_as_argument/server.go
+++ b/example/array_as_argument/server.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+)
+
+type query struct{}
+
+type IntInput struct {
+	A int32
+	B int32
+}
+
+func (_ *query) Reversed(args struct{ Values []string }) []string {
+	result := make([]string, len(args.Values))
+
+	for i, value := range args.Values {
+		for _, v := range value {
+			result[i] = string(v) + result[i]
+		}
+	}
+	return result
+}
+
+func (_ *query) Sums(args struct{ Values []IntInput }) []int32 {
+	result := make([]int32, len(args.Values))
+
+	for i, value := range args.Values {
+		result[i] = value.A + value.B
+	}
+	return result
+}
+
+func main() {
+	s := `
+		input IntInput {
+			a: Int!
+			b: Int!
+		}
+
+		type Query {
+			reversed(values: [String!]!): [String!]!
+			sums(values: [IntInput!]!): [Int!]!
+		}
+	`
+	schema := graphql.MustParseSchema(s, &query{})
+	http.Handle("/query", &relay.Handler{Schema: schema})
+
+	log.Println("Listen in port :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+/*
+	* The following query
+
+	query{
+		reversed(values:["hello", "hi"])
+		sums(values:[{a:2,b:3},{a:-10,b:-1}])
+	}
+
+	* will return
+
+	{
+		"data": {
+			"reversed": [
+				"olleh",
+				"ih"
+			],
+			"sums": [
+				5,
+				-11
+			]
+		}
+	}
+*/

--- a/example/social/introspect.json
+++ b/example/social/introspect.json
@@ -70,6 +70,29 @@
           "INLINE_FRAGMENT"
         ],
         "name": "skip"
+      },
+      {
+        "args": [
+          {
+            "defaultValue": null,
+            "description": "The URL should point to a human-readable specification of the data format, serialization, and coercion rules.",
+            "name": "url",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "description": "Provides a scalar specification URL for specifying the behavior of custom scalar types.",
+        "locations": [
+          "SCALAR"
+        ],
+        "name": "specifiedBy"
       }
     ],
     "mutationType": null,
@@ -1337,6 +1360,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
+              "ofType": null
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "specifiedByURL",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             }
           }

--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -70,6 +70,29 @@
           "INLINE_FRAGMENT"
         ],
         "name": "skip"
+      },
+      {
+        "args": [
+          {
+            "defaultValue": null,
+            "description": "The URL should point to a human-readable specification of the data format, serialization, and coercion rules.",
+            "name": "url",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "description": "Provides a scalar specification URL for specifying the behavior of custom scalar types.",
+        "locations": [
+          "SCALAR"
+        ],
+        "name": "specifiedBy"
       }
     ],
     "mutationType": {
@@ -1979,6 +2002,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
+              "ofType": null
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "specifiedByURL",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             }
           }

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -51,8 +51,7 @@ func RunTest(t *testing.T, test *Test) {
 
 	if test.ExpectedResult == "" {
 		if result.Data != nil {
-			t.Fatalf("got: %s", result.Data)
-			t.Fatalf("want: null")
+			t.Fatalf("got: %s, want: null", result.Data)
 		}
 		return
 	}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -626,7 +626,7 @@ func TestEmbeddedStruct(t *testing.T) {
 				type Query {
 					course: Course!
 				}
-				
+
 				type Course {
 					name: String!
 					createdAt: String!
@@ -1494,6 +1494,40 @@ func TestDeprecatedDirective(t *testing.T) {
 	})
 }
 
+func TestSpecifiedByDirective(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+			schema {
+				query: Query
+			}
+			type Query {
+			}
+			scalar UUID @specifiedBy(
+				url: "https://tools.ietf.org/html/rfc4122"
+			)
+			`, &struct{}{}),
+			Query: `
+				query {
+					__type(name: "UUID") {
+						name
+						specifiedByURL
+					}
+				}
+			`,
+			Variables: map[string]interface{}{},
+			ExpectedResult: `
+				{
+					"__type": {
+						"name": "UUID",
+						"specifiedByURL": "https://tools.ietf.org/html/rfc4122"
+					}
+				}
+			`,
+		},
+	})
+}
+
 type testBadEnumResolver struct{}
 
 func (r *testBadEnumResolver) Hero() *testBadEnumCharacterResolver {
@@ -1854,11 +1888,11 @@ func TestTypeName(t *testing.T) {
 						}
 					}
 				}
-				
+
 				fragment Droid on Droid {
 					name
 					__typename
-				}			  
+				}
 			`,
 			RawResponse:    true,
 			ExpectedResult: `{"hero":{"__typename":"Droid","name":"R2-D2"}}`,
@@ -2474,6 +2508,26 @@ func TestIntrospection(t *testing.T) {
 												"ofType": {
 													"kind": "SCALAR",
 													"name": "Boolean"
+												}
+											}
+										}
+									]
+								},
+								{
+									"name": "specifiedBy",
+									"description": "Provides a scalar specification URL for specifying the behavior of custom scalar types.",
+									"locations": [
+										"SCALAR"
+									],
+									"args": [
+										{
+											"name": "url",
+											"description": "The URL should point to a human-readable specification of the data format, serialization, and coercion rules.",
+											"type": {
+												"kind": "NON_NULL",
+												"ofType": {
+													"kind": "SCALAR",
+													"name": "String"
 												}
 											}
 										}
@@ -3800,7 +3854,7 @@ func TestPanicAmbiguity(t *testing.T) {
 			name: String!
 			university: University!
 		}
-		
+
 		type University {
 			name: String!
 		}
@@ -4300,11 +4354,11 @@ func TestQueryVariablesValidation(t *testing.T) {
 			  	required: String!
 			  	optional: String
 			}
-			
+
 			type SearchResults {
 				match: String
 			}
-			
+
 			type Query {
 				search(filter: SearchFilter!): [SearchResults!]!
 			}`, &queryVarResolver{}, graphql.UseFieldResolvers()),
@@ -4325,11 +4379,11 @@ func TestQueryVariablesValidation(t *testing.T) {
 				required: String!
 				optional: String
 			}
-			
+
 			type SearchResults {
 				match: String
 			}
-			
+
 			type Query {
 				search(filter: SearchFilter!): [SearchResults!]!
 			}`, &queryVarResolver{}, graphql.UseFieldResolvers()),

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"sync"
 	"testing"
 	"time"
@@ -3951,6 +3952,52 @@ func TestSubscriptions_In_Exec(t *testing.T) {
 			},
 		},
 	})
+}
+
+// This test assigns a hello resolver to the schema, along with 2 middlewares injected via SchemaOpt.
+// Then the test asserts that both middlewares were called and resolver output still works as expected.
+func TestMiddlewares_In_Exec(t *testing.T) {
+	resolver := &helloResolver{}
+	r := &struct {
+		*helloResolver
+	}{
+		helloResolver: resolver,
+	}
+	var m1Called, m2Called bool
+	gqltesting.RunTest(t, &gqltesting.Test{
+		Schema: graphql.MustParseSchema(`
+			type Query {
+				hello: String!
+			}
+		`, r,
+			graphql.WithMiddlewares(
+				func(next graphql.Exec) graphql.Exec {
+					return func(ctx context.Context, q string, o string, v map[string]interface{}, r *resolvable.Schema) *graphql.Response {
+						m1Called = true
+						return next(ctx, q, o, v, r)
+					}
+				},
+				func(next graphql.Exec) graphql.Exec {
+					return func(ctx context.Context, q string, o string, v map[string]interface{}, r *resolvable.Schema) *graphql.Response {
+						m2Called = true
+						return next(ctx, q, o, v, r)
+					}
+				},
+			),
+		),
+		ExpectedResult: fmt.Sprintf(`{"hello":"%s"}`, resolver.Hello()),
+		Query: `
+			query { 
+				hello
+			}
+		`,
+	})
+	if !m1Called {
+		t.Fatalf("middleware1 was set but was not called")
+	}
+	if !m2Called {
+		t.Fatalf("middleware2 was set but was not called")
+	}
 }
 
 type nilPointerReturnValue struct{}

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -59,6 +59,12 @@ var metaSrc = `
 		reason: String = "No longer supported"
 	) on FIELD_DEFINITION | ENUM_VALUE
 
+	# Provides a scalar specification URL for specifying the behavior of custom scalar types.
+	directive @specifiedBy(
+		# The URL should point to a human-readable specification of the data format, serialization, and coercion rules.
+		url: String!
+	) on SCALAR
+
 	# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 	#
 	# In some cases, you need to provide options to alter GraphQL's execution behavior
@@ -179,6 +185,7 @@ var metaSrc = `
 		enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
 		inputFields: [__InputValue!]
 		ofType: __Type
+		specifiedByURL: String
 	}
 
 	# An enum describing what kind of type a given ` + "`" + `__Type` + "`" + ` is.

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -268,8 +268,18 @@ func resolveNamedType(s *types.Schema, t types.NamedType) error {
 				return err
 			}
 		}
+		if err := resolveDirectives(s, t.Directives, "INTERFACE"); err != nil {
+			return err
+		}
 	case *types.InputObject:
 		if err := resolveInputObject(s, t.Values); err != nil {
+			return err
+		}
+		if err := resolveDirectives(s, t.Directives, "INPUT_OBJECT"); err != nil {
+			return err
+		}
+	case *types.ScalarTypeDefinition:
+		if err := resolveDirectives(s, t.Directives, "SCALAR"); err != nil {
 			return err
 		}
 	}
@@ -335,6 +345,11 @@ func resolveInputObject(s *types.Schema, values types.ArgumentsDefinition) error
 			return err
 		}
 		v.Type = t
+
+		if err := resolveDirectives(s, v.Directives, "ARGUMENT_DEFINITION"); err != nil {
+			return err
+		}
+
 	}
 	return nil
 }

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -920,6 +920,22 @@ Second line of the description.
 				return nil
 			},
 		},
+		{
+			name: "Disallow repeat of a directive if it is not `repeatable`",
+			sdl: `
+			directive @nonrepeatabledirective on FIELD_DEFINITION
+			type Foo {
+				bar: String @nonrepeatabledirective @nonrepeatabledirective
+			}
+			`,
+			validateError: func(err error) error {
+				prefix := `graphql: non repeatable directive "nonrepeatabledirective" can not be repeated. Consider adding "repeatable"`
+				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
+				}
+				return nil
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			s, err := schema.ParseSchema(test.sdl, test.useStringDescriptions)

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -936,6 +936,60 @@ Second line of the description.
 				return nil
 			},
 		},
+		{
+			name: "Decorating scalar with an undeclared directive should return an error",
+			sdl: `
+			scalar S @undeclareddirective
+			`,
+			validateError: func(err error) error {
+				prefix := `graphql: directive "undeclareddirective" not found`
+				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Decorating argument with an undeclared directive should return an error",
+			sdl: `
+			type Query {
+				hello(name: String! @undeclareddirective): String!
+			}
+			`,
+			validateError: func(err error) error {
+				prefix := `graphql: directive "undeclareddirective" not found`
+				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Decorating input object with an undeclared directive should return an error",
+			sdl: `
+			input InputObject @undeclareddirective{}
+			`,
+			validateError: func(err error) error {
+				prefix := `graphql: directive "undeclareddirective" not found`
+				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Decorating interface with an undeclared directive should return an error",
+			sdl: `
+			interface I @undeclareddirective {}
+			`,
+			validateError: func(err error) error {
+				prefix := `graphql: directive "undeclareddirective" not found`
+				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
+				}
+				return nil
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			s, err := schema.ParseSchema(test.sdl, test.useStringDescriptions)

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -189,6 +189,20 @@ func (r *Type) OfType() *Type {
 	}
 }
 
+func (r *Type) SpecifiedByURL() *string {
+	switch t := r.typ.(type) {
+	case *types.ScalarTypeDefinition:
+		if d := t.Directives.Get("specifiedBy"); d != nil {
+			arg := d.Arguments.MustGet("url")
+			url := arg.Deserialize(nil).(string)
+			return &url
+		}
+	default:
+		return nil
+	}
+	return nil
+}
+
 type Field struct {
 	field *types.FieldDefinition
 }

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,26 @@
+package graphql
+
+import (
+	"context"
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
+)
+
+// Exec executes the given query with the schema's resolver.
+type Exec func(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, res *resolvable.Schema) *Response
+
+// Middleware can wrap Exec to add additional behaviour
+type Middleware func(next Exec) Exec
+
+func ParseErrorsMiddleware(parseErrors func([]*errors.QueryError) []*errors.QueryError) Middleware {
+	return func(next Exec) Exec {
+		return func(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, res *resolvable.Schema) *Response {
+			// perform the original query
+			response := next(ctx, queryString, operationName, variables, res)
+			// mutate the errors
+			response.Errors = parseErrors(response.Errors)
+			// return the response
+			return response
+		}
+	}
+}

--- a/trace/opentracing/trace.go
+++ b/trace/opentracing/trace.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 )
 
-// Tracer implements the graphql-go Tracer inteface and creates OpenTracing spans.
+// Tracer implements the graphql-go Tracer interface and creates OpenTracing spans.
 type Tracer struct{}
 
 func (Tracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, func([]*errors.QueryError)) {


### PR DESCRIPTION
Super simple contribution in order to enable middlewareing the execution of the schema. I also added a `ParseErrorsMiddleware ` middleware that will be helpful in our backend repo to manage errors and select which ones should go to bugnsag, notifications, etc. 

Also a bunch of updates come in from the main repository, but nothing concerning