### PR TITLE
Introduce exec middlewares

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,26 @@
+package graphql
+
+import (
+	"context"
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
+)
+
+// Exec executes the given query with the schema's resolver.
+type Exec func(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, res *resolvable.Schema) *Response
+
+// Middleware can wrap Exec to add additional behaviour
+type Middleware func(next Exec) Exec
+
+func ParseErrorsMiddleware(parseErrors func([]*errors.QueryError) []*errors.QueryError) Middleware {
+	return func(next Exec) Exec {
+		return func(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, res *resolvable.Schema) *Response {
+			// perform the original query
+			response := next(ctx, queryString, operationName, variables, res)
+			// mutate the errors
+			response.Errors = parseErrors(response.Errors)
+			// return the response
+			return response
+		}
+	}
+}


### PR DESCRIPTION
Super simple contribution in order to enable middlewareing the execution of the schema. I also added a ParseErrorsMiddleware middleware that will be helpful in our backend repo to manage errors and select which ones should go to bugnsag, notifications, etc.