### PR TITLE
Expose query.Parse at the top level

### DIFF
--- a/parse_query.go
+++ b/parse_query.go
@@ -1,0 +1,13 @@
+package graphql
+
+import (
+	"github.com/graph-gophers/graphql-go/ast"
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/query"
+)
+
+// ParseQuery parses a GraphQL query string and returns the AST root node and
+// any errors. It only serves to expose the internal query.Parse function.
+func ParseQuery(queryString string) (*ast.ExecutableDefinition, *errors.QueryError) {
+	return query.Parse(queryString)
+}


### PR DESCRIPTION
Instead of parsing the queries on our own, let's expose an internal method of the library.