### PR TITLE
feat: exit processing on context cancel

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -96,6 +96,7 @@ func (r *Request) execSelections(ctx context.Context, sels []selected.Selection,
 
 	var fields []*fieldToExec
 	collectFieldsToResolve(sels, s, resolver, &fields, make(map[string]*fieldToExec))
+
 	if async {
 		var wg sync.WaitGroup
 		wg.Add(len(fields))
@@ -213,8 +214,6 @@ func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f
 	defer func() {
 		finish(err)
 	}()
-
-	fmt.Println(time.Now(), "execFieldSelection", f.field.Name, f.field.TypeName, f.field.Args)
 
 	err = func() (err *errors.QueryError) {
 		defer func() {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -195,6 +195,13 @@ func typeOf(tf *selected.TypenameField, resolver reflect.Value) string {
 }
 
 func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f *fieldToExec, path *pathSegment, applyLimiter bool) {
+	// Exit early if the context has been cancelled.
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
 	if applyLimiter {
 		r.Limiter <- struct{}{}
 	}
@@ -206,13 +213,6 @@ func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f
 	defer func() {
 		finish(err)
 	}()
-
-	select {
-	case <-ctx.Done():
-		fmt.Println(time.Now(), "execFieldSelection", f.field.Name, f.field.TypeName, f.field.Args, "ctx.Done()")
-		return
-	default:
-	}
 
 	fmt.Println(time.Now(), "execFieldSelection", f.field.Name, f.field.TypeName, f.field.Args)
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -96,7 +96,6 @@ func (r *Request) execSelections(ctx context.Context, sels []selected.Selection,
 
 	var fields []*fieldToExec
 	collectFieldsToResolve(sels, s, resolver, &fields, make(map[string]*fieldToExec))
-	fmt.Println("Running async = ", async)
 	if async {
 		var wg sync.WaitGroup
 		wg.Add(len(fields))
@@ -207,6 +206,15 @@ func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f
 	defer func() {
 		finish(err)
 	}()
+
+	select {
+	case <-ctx.Done():
+		fmt.Println(time.Now(), "execFieldSelection", f.field.Name, f.field.TypeName, f.field.Args, "ctx.Done()")
+		return
+	default:
+	}
+
+	fmt.Println(time.Now(), "execFieldSelection", f.field.Name, f.field.TypeName, f.field.Args)
 
 	err = func() (err *errors.QueryError) {
 		defer func() {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -96,7 +96,7 @@ func (r *Request) execSelections(ctx context.Context, sels []selected.Selection,
 
 	var fields []*fieldToExec
 	collectFieldsToResolve(sels, s, resolver, &fields, make(map[string]*fieldToExec))
-
+	fmt.Println("Running async = ", async)
 	if async {
 		var wg sync.WaitGroup
 		wg.Add(len(fields))


### PR DESCRIPTION
The goal is to interrupt resolver processing upon request being canceled.